### PR TITLE
Add Fiber health check endpoint

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,6 @@
 module monty
 
 go 1.23.4
+
+require github.com/gofiber/fiber/v2 v2.52.0
+

--- a/handlers/health.go
+++ b/handlers/health.go
@@ -1,0 +1,11 @@
+package handlers
+
+import "github.com/gofiber/fiber/v2"
+
+func RegisterHealth(app *fiber.App) {
+	app.Get("/health", healthHandler)
+}
+
+func healthHandler(c *fiber.Ctx) error {
+	return c.JSON(fiber.Map{"status": "ok"})
+}

--- a/main.go
+++ b/main.go
@@ -1,0 +1,14 @@
+package main
+
+import (
+	"github.com/gofiber/fiber/v2"
+	"monty/handlers"
+)
+
+func main() {
+	app := fiber.New()
+
+	handlers.RegisterHealth(app)
+
+	app.Listen(":3000")
+}


### PR DESCRIPTION
## Summary
- add Fiber v2 to module
- implement `/health` JSON endpoint
- refactor health route into its own handler

## Testing
- `go mod tidy` (fails: Forbidden when fetching github.com/gofiber/fiber/v2)
- `go test ./...` (fails: missing go.sum entry for github.com/gofiber/fiber/v2)


------
https://chatgpt.com/codex/tasks/task_e_68c160cf2f3083208f4fa0b56e4e1e84