### PR TITLE
Add endpoint worker

### DIFF
--- a/main.go
+++ b/main.go
@@ -3,12 +3,18 @@ package main
 import (
 	"github.com/gofiber/fiber/v2"
 	"github.com/monty/handlers"
+	"github.com/monty/worker"
+	"time"
 )
 
 func main() {
 	app := fiber.New()
 
 	handlers.RegisterHealth(app)
+
+	worker.Start([]worker.Endpoint{
+		{URL: "http://localhost:3000/health", Interval: 10 * time.Second},
+	})
 
 	app.Listen(":3000")
 }

--- a/worker/worker.go
+++ b/worker/worker.go
@@ -1,0 +1,29 @@
+package worker
+
+import (
+	"log"
+	"net/http"
+	"time"
+)
+
+type Endpoint struct {
+	URL      string
+	Interval time.Duration
+}
+
+func Start(endpoints []Endpoint) {
+	for _, ep := range endpoints {
+		go func(ep Endpoint) {
+			ticker := time.NewTicker(ep.Interval)
+			for range ticker.C {
+				resp, err := http.Get(ep.URL)
+				if err != nil {
+					log.Printf("error requesting %s: %v", ep.URL, err)
+					continue
+				}
+				log.Printf("GET %s -> %s", ep.URL, resp.Status)
+				resp.Body.Close()
+			}
+		}(ep)
+	}
+}


### PR DESCRIPTION
## Summary
- add Endpoint struct with URL and interval fields
- add background worker to periodically GET endpoints and log statuses
- wire worker into main with sample health check endpoint

## Testing
- `go test ./...`
- `go vet ./...`


------
https://chatgpt.com/codex/tasks/task_e_68c2bda5e43083209e64814fdeac4462