### PR TITLE
Allow worker to fire requests concurrently

### DIFF
--- a/worker/worker.go
+++ b/worker/worker.go
@@ -16,13 +16,15 @@ func Start(endpoints []Endpoint) {
 		go func(ep Endpoint) {
 			ticker := time.NewTicker(ep.Interval)
 			for range ticker.C {
-				resp, err := http.Get(ep.URL)
-				if err != nil {
-					log.Printf("error requesting %s: %v", ep.URL, err)
-					continue
-				}
-				log.Printf("GET %s -> %s", ep.URL, resp.Status)
-				resp.Body.Close()
+				go func(url string) {
+					resp, err := http.Get(url)
+					if err != nil {
+						log.Printf("error requesting %s: %v", url, err)
+						return
+					}
+					log.Printf("GET %s -> %s", url, resp.Status)
+					resp.Body.Close()
+				}(ep.URL)
 			}
 		}(ep)
 	}


### PR DESCRIPTION
## Summary
- let each worker tick spawn a goroutine so slow requests don't block

## Testing
- `go vet ./...`
- `go test ./...`
- `go build ./...`


------
https://chatgpt.com/codex/tasks/task_e_68c2bf6e6eec83208bdcdb906bcb0694