### PR TITLE
Add PostgreSQL integration with migrations and seeding

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -2,18 +2,23 @@ module github.com/monty
 
 go 1.23.4
 
-require github.com/gofiber/fiber/v2 v2.52.0
+require (
+    github.com/gofiber/fiber/v2 v2.52.0
+    gorm.io/driver/postgres v1.5.2
+    gorm.io/gorm v1.25.5
+    github.com/google/uuid v1.5.0
+)
 
 require (
-	github.com/andybalholm/brotli v1.0.5 // indirect
-	github.com/google/uuid v1.5.0 // indirect
-	github.com/klauspost/compress v1.17.0 // indirect
-	github.com/mattn/go-colorable v0.1.13 // indirect
-	github.com/mattn/go-isatty v0.0.20 // indirect
-	github.com/mattn/go-runewidth v0.0.15 // indirect
-	github.com/rivo/uniseg v0.2.0 // indirect
-	github.com/valyala/bytebufferpool v1.0.0 // indirect
-	github.com/valyala/fasthttp v1.51.0 // indirect
-	github.com/valyala/tcplisten v1.0.0 // indirect
-	golang.org/x/sys v0.15.0 // indirect
+    github.com/andybalholm/brotli v1.0.5 // indirect
+    github.com/klauspost/compress v1.17.0 // indirect
+    github.com/mattn/go-colorable v0.1.13 // indirect
+    github.com/mattn/go-isatty v0.0.20 // indirect
+    github.com/mattn/go-runewidth v0.0.15 // indirect
+    github.com/rivo/uniseg v0.2.0 // indirect
+    github.com/valyala/bytebufferpool v1.0.0 // indirect
+    github.com/valyala/fasthttp v1.51.0 // indirect
+    github.com/valyala/tcplisten v1.0.0 // indirect
+    golang.org/x/sys v0.15.0 // indirect
 )
+

--- a/handlers/endpoint.go
+++ b/handlers/endpoint.go
@@ -1,0 +1,40 @@
+package handlers
+
+import (
+	"time"
+
+	"github.com/gofiber/fiber/v2"
+	"github.com/google/uuid"
+	"github.com/monty/models"
+)
+
+func RegisterEndpoints(app *fiber.App) {
+	app.Get("/endpoints", listEndpoints)
+	app.Post("/endpoints", createEndpoint)
+}
+
+func listEndpoints(c *fiber.Ctx) error {
+	var endpoints []models.Endpoint
+	models.DB.Find(&endpoints)
+	return c.JSON(endpoints)
+}
+
+func createEndpoint(c *fiber.Ctx) error {
+	var input struct {
+		URL      string `json:"url"`
+		Interval int    `json:"interval"`
+	}
+	if err := c.BodyParser(&input); err != nil {
+		return c.Status(fiber.StatusBadRequest).JSON(fiber.Map{"error": "invalid input"})
+	}
+	ep := models.Endpoint{
+		ID:        uuid.New().String(),
+		URL:       input.URL,
+		Interval:  input.Interval,
+		CreatedAt: time.Now(),
+	}
+	if err := models.DB.Create(&ep).Error; err != nil {
+		return c.Status(fiber.StatusInternalServerError).JSON(fiber.Map{"error": "could not create endpoint"})
+	}
+	return c.Status(fiber.StatusCreated).JSON(ep)
+}

--- a/main.go
+++ b/main.go
@@ -1,20 +1,32 @@
 package main
 
 import (
+	"time"
+
 	"github.com/gofiber/fiber/v2"
 	"github.com/monty/handlers"
+	"github.com/monty/models"
 	"github.com/monty/worker"
-	"time"
 )
 
 func main() {
+	models.ConnectDatabase()
+	if err := models.Seed(); err != nil {
+		panic(err)
+	}
+
 	app := fiber.New()
 
 	handlers.RegisterHealth(app)
+	handlers.RegisterEndpoints(app)
 
-	worker.Start([]worker.Endpoint{
-		{URL: "http://localhost:3000/health", Interval: 10 * time.Second},
-	})
+	var eps []models.Endpoint
+	models.DB.Find(&eps)
+	var workerEps []worker.Endpoint
+	for _, ep := range eps {
+		workerEps = append(workerEps, worker.Endpoint{URL: ep.URL, Interval: time.Duration(ep.Interval) * time.Second})
+	}
+	worker.Start(workerEps)
 
 	app.Listen(":3000")
 }

--- a/models/database.go
+++ b/models/database.go
@@ -1,0 +1,27 @@
+package models
+
+import (
+	"log"
+	"os"
+
+	"gorm.io/driver/postgres"
+	"gorm.io/gorm"
+)
+
+var DB *gorm.DB
+
+func ConnectDatabase() {
+	dsn := os.Getenv("DATABASE_URL")
+	if dsn == "" {
+		log.Fatal("DATABASE_URL is not set")
+	}
+	var err error
+	DB, err = gorm.Open(postgres.Open(dsn), &gorm.Config{})
+	if err != nil {
+		log.Fatalf("failed to connect database: %v", err)
+	}
+
+	if err := DB.AutoMigrate(&Endpoint{}, &Status{}); err != nil {
+		log.Fatalf("failed to migrate: %v", err)
+	}
+}

--- a/models/endpoint.go
+++ b/models/endpoint.go
@@ -3,8 +3,8 @@ package models
 import "time"
 
 type Endpoint struct {
-	ID        string        `json:"id"`
-	URL       string        `json:"url"`
-	Interval  time.Duration `json:"interval"`
-	CreatedAt time.Time     `json:"created_at"`
+	ID        string    `gorm:"primaryKey" json:"id"`
+	URL       string    `json:"url"`
+	Interval  int       `json:"interval"` // seconds
+	CreatedAt time.Time `json:"created_at"`
 }

--- a/models/seed.go
+++ b/models/seed.go
@@ -1,0 +1,23 @@
+package models
+
+import (
+	"time"
+
+	"github.com/google/uuid"
+)
+
+// Seed inserts default endpoints if none exist
+func Seed() error {
+	var count int64
+	DB.Model(&Endpoint{}).Count(&count)
+	if count > 0 {
+		return nil
+	}
+	ep := Endpoint{
+		ID:        uuid.New().String(),
+		URL:       "http://localhost:3000/health",
+		Interval:  10, // seconds
+		CreatedAt: time.Now(),
+	}
+	return DB.Create(&ep).Error
+}

--- a/models/status.go
+++ b/models/status.go
@@ -3,7 +3,7 @@ package models
 import "time"
 
 type Status struct {
-	ID         string    `json:"id"`
+	ID         string    `gorm:"primaryKey" json:"id"`
 	EndpointID string    `json:"endpoint_id"`
 	Code       int       `json:"code"`
 	CheckedAt  time.Time `json:"checked_at"`


### PR DESCRIPTION
## Summary
- connect to PostgreSQL via GORM and auto-migrate models
- seed database with a default health endpoint
- expose endpoints API for listing and creating monitors
- load endpoints from DB and start worker accordingly

## Testing
- `go mod tidy` (fails: unrecognized import path "gorm.io/driver/postgres": Forbidden)
- `go build ./...` (fails: missing go.sum entry for gorm.io/driver/postgres)


------
https://chatgpt.com/codex/tasks/task_e_68c2c5e8fa5c8320982eb66d1a688666