### PR TITLE
Add Docker Compose setup with Postgres

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,12 @@
+FROM golang:1.24-alpine AS build
+WORKDIR /app
+COPY go.mod go.sum ./
+RUN go mod download
+COPY . .
+RUN CGO_ENABLED=0 GOOS=linux go build -o monty
+
+FROM alpine:3.18
+WORKDIR /app
+COPY --from=build /app/monty .
+EXPOSE 3000
+CMD ["./monty"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,21 @@
+version: "3.9"
+services:
+  app:
+    build: .
+    ports:
+      - "3000:3000"
+    environment:
+      DATABASE_URL: postgres://monty:monty@postgres:5432/monty?sslmode=disable
+    depends_on:
+      - postgres
+  postgres:
+    image: postgres:15
+    restart: always
+    environment:
+      POSTGRES_USER: monty
+      POSTGRES_PASSWORD: monty
+      POSTGRES_DB: monty
+    volumes:
+      - postgres-data:/var/lib/postgresql/data
+volumes:
+  postgres-data:


### PR DESCRIPTION
## Summary
- add multi-stage Dockerfile for building Go service
- provide docker-compose for app with Postgres database

## Testing
- `go fmt ./...`
- `go vet -mod=readonly ./...` *(fails: missing go.sum entry for gorm)*
- `go build -mod=readonly ./...` *(fails: missing go.sum entry for gorm)*

------
https://chatgpt.com/codex/tasks/task_e_68c410b6f75c832095333dfe0b39095f