### PR TITLE
Ensure app waits for Postgres to become ready

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -7,7 +7,8 @@ services:
     environment:
       DATABASE_URL: postgres://monty:monty@postgres:5432/monty?sslmode=disable
     depends_on:
-      - postgres
+      postgres:
+        condition: service_healthy
   postgres:
     image: postgres:15
     restart: always
@@ -17,5 +18,10 @@ services:
       POSTGRES_DB: monty
     volumes:
       - postgres-data:/var/lib/postgresql/data
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U $${POSTGRES_USER}"]
+      interval: 5s
+      timeout: 5s
+      retries: 5
 volumes:
   postgres-data:


### PR DESCRIPTION
## Summary
- add a healthcheck for the Postgres service in docker-compose
- wait for the Postgres healthcheck before starting the app

## Testing
- `docker compose config` *(fails: command not found)*
- `go build ./...` *(fails: missing go.sum entry for gorm dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_68c5b64de7a483209134c48651c904bb