### PR TITLE
Add endpoint URL listing endpoint

### DIFF
--- a/handlers/endpoint.go
+++ b/handlers/endpoint.go
@@ -11,12 +11,23 @@ import (
 func RegisterEndpoints(app *fiber.App) {
 	app.Get("/endpoints", listEndpoints)
 	app.Post("/endpoints", createEndpoint)
+	app.Get("/endpoint-urls", listEndpointURLs)
 }
 
 func listEndpoints(c *fiber.Ctx) error {
 	var endpoints []models.Endpoint
 	models.DB.Find(&endpoints)
 	return c.JSON(endpoints)
+}
+
+func listEndpointURLs(c *fiber.Ctx) error {
+	var endpoints []models.Endpoint
+	models.DB.Find(&endpoints)
+	urls := make([]string, len(endpoints))
+	for i, ep := range endpoints {
+		urls[i] = ep.URL
+	}
+	return c.JSON(urls)
 }
 
 func createEndpoint(c *fiber.Ctx) error {


### PR DESCRIPTION
## Summary
- add `/endpoint-urls` GET endpoint to list only the URLs of registered endpoints

## Testing
- `go test ./...` *(fails: missing go.sum entry for gorm dependencies)*
- `go mod tidy` *(fails: unable to download modules from proxy.golang.org)*

------
https://chatgpt.com/codex/tasks/task_e_68c69290e6e083209070384a0f0b4145